### PR TITLE
add github ISSUE_TEMPLATE folder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,9 +12,9 @@ body:
         If you have a question about how to achieve something and are struggling, please post a question
 
         Before submitting a new bug/issue, please check the links below to see if there is a solution or question posted there already:
-         - `desploy.sh` Issues tab: https://github.com/gabrielcsapo/deploy.sh/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
-         - `desploy.sh` Closed issues tab: https://github.com/gabrielcsapo/deploy.sh/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed
-         - `desploy.sh` Discussion's tab: https://github.com/gabrielcsapo/deploy.sh/discussions
+         - `deploy.sh` Issues tab: https://github.com/gabrielcsapo/deploy.sh/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+         - `deploy.sh` Closed issues tab: https://github.com/gabrielcsapo/deploy.sh/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed
+         - `deploy.sh` Discussion's tab: https://github.com/gabrielcsapo/deploy.sh/discussions
 
         The more information you fill in, the better the community can help you.
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,105 @@
+name: "🐛 Bug report"
+title: "[BUG] - YOUR_BUG_TITLE_HERE_REPLACE_ME"
+labels: [bug]
+description: Create a report to help us improve
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting an issue :pray:.
+
+        This issue tracker is for reporting bugs found in `desploy.sh` (https://github.com/gabrielcsapo/deploy.sh).
+        If you have a question about how to achieve something and are struggling, please post a question
+
+        Before submitting a new bug/issue, please check the links below to see if there is a solution or question posted there already:
+         - `desploy.sh` Issues tab: https://github.com/gabrielcsapo/deploy.sh/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+         - `desploy.sh` Closed issues tab: https://github.com/gabrielcsapo/deploy.sh/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed
+         - `desploy.sh` Discussion's tab: https://github.com/gabrielcsapo/deploy.sh/discussions
+
+        The more information you fill in, the better the community can help you.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: Provide a clear and concise description of the challenge you are running into.
+    validations:
+      required: true
+  - type: input
+    id: link
+    attributes:
+      label: Minimal Reproduction
+      description: Provide a **minimal** example to reproduce the bug.
+      placeholder: Github Repo link
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce the Bug or Issue
+      description: Describe the steps we have to take to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Provide a clear and concise description of what you expected to happen.
+      placeholder: |
+        As a user, I expected ___ behavior but i am seeing ___
+    validations:
+      required: true
+  - type: dropdown
+    id: operating_system_type
+    attributes:
+      label: Operating System Type
+      description: What web operating system are you using?
+      options:
+        - MacOS
+        - Windows
+        - Other (please write in Additional Context)
+    validations:
+      required: true
+  - type: input
+    id: docker_version
+    attributes:
+      label: Docker Version
+      description: What version of Docker are you using? (_type `docker --version` in your terminal_)
+      placeholder: Your Node.js Version
+    validations:
+      required: true
+  - type: input
+    id: nodejs_version
+    attributes:
+      label: Node.js Version
+      description: What version of Node.js are you using? (_type `node --version` in your terminal_)
+      placeholder: Your Node.js Version
+    validations:
+      required: true
+  - type: input
+    id: deploysh_version
+    attributes:
+      label: deploy.sh Version
+      description: What version of deploy.sh are you using?
+      placeholder: deploy.sh version
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots_or_videos
+    attributes:
+      label: Screenshots or Videos
+      description: |
+        If applicable, add screenshots or a video to help explain your problem.
+        For more information on the supported file image/file types and the file size limits, please refer
+        to the following link: https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/attaching-files
+      placeholder: |
+        You can drag your video or image files inside of this editor ↓
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thank you for reporting an issue :pray:.
 
-        This issue tracker is for reporting bugs found in `desploy.sh` (https://github.com/gabrielcsapo/deploy.sh).
+        This issue tracker is for reporting bugs found in `deploy.sh` (https://github.com/gabrielcsapo/deploy.sh).
         If you have a question about how to achieve something and are struggling, please post a question
 
         Before submitting a new bug/issue, please check the links below to see if there is a solution or question posted there already:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Feature Requests & Questions
+    url: https://github.com/gabrielcsapo/deploy.sh/discussions
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature request
+title: "[Feature Request] YOUR_FEATURE_TITLE_HERE_REPLACE_ME"
+labels: [feature request]
+description: |
+  💡 Suggest an idea for the `deploy.sh` project
+  Examples
+    - propose a new component
+    - improve an exiting component
+    - ....etc
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue form is for requesting features only! For example, requesting a new component, behavior ... etc
+        If you want to report a bug, please use the [bug report form](https://github.com/gabrielcsapo/deploy.sh/issues/new?assignees=&labels=&template=bug_report.yml).
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+      placeholder: |
+        As a user, I expected ___ behavior but ___ ...
+
+        Ideal Steps I would like to see:
+        1. Go to '...'
+        2. Click on '....'
+        3. ....
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+  - type: textarea
+    attributes:
+      label: Screenshots or Videos
+      description: |
+        If applicable, add screenshots or a video to help explain your problem.
+        For more information on the supported file image/file types and the file size limits, please refer
+        to the following link: https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/attaching-files
+      placeholder: |
+        You can drag your video or image files inside of this editor ↓
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13204,7 +13204,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.13.0",
@@ -13633,7 +13634,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -17161,7 +17163,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -18141,7 +18144,8 @@
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz",
       "integrity": "sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "marked": {
       "version": "4.0.12",
@@ -21095,7 +21099,8 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",


### PR DESCRIPTION
## What is the change?
1. add `bug_report.yml` & `feature_request.yml` to enable Github's form based issue template
   - https://youtu.be/qQE1BUkf2-s?t=23
2.  add `config.yml` file to help direct users to the helpful pages


## Motivation
- encourage's bug reporter's to put more care into their bug report before submission
- this may help maintainer's receive more detailed & higher quality bug report's
- adds helpful tips for user's during the process of creating a bug/issue report

## Demo of Change
- this PR is similar to this one I created for `solidjs` repo: https://github.com/solidjs/solid/blob/main/.github/ISSUE_TEMPLATE/bug_report.yml
